### PR TITLE
Fix Fastify Next.js dependency compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
-    "@fastify/nextjs": "^10.0.2",
+    "@fastify/nextjs": "^11.0.0",
     "fastify": "^4.26.2",
-    "next": "^14.2.5",
+    "next": "^13.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
## Summary
- update @fastify/nextjs to the latest available major release supported by the registry
- align the Next.js dependency version with the plugin's peer requirement to prevent installation failures

## Testing
- npm install *(fails: registry returned 403 for @fastify/under-pressure)*

------
https://chatgpt.com/codex/tasks/task_b_68e4a3a69b18832ba600a954ab642460